### PR TITLE
blazegraph_load_test.sh - create/reset/destroy the test namespace

### DIFF
--- a/blazegraph_load_test.sh
+++ b/blazegraph_load_test.sh
@@ -10,6 +10,69 @@ if [ -z "$SPARQL_URI" ]; then
 fi
 
 # ---
+# Create or recreate the test namespace
+
+# parse the namespace from the SPARQL_URI
+export bg_url=$(echo $SPARQL_URI | sed -e 's#\(.*\)/namespace.*#\1#')
+export bg_namespace=$(echo $SPARQL_URI | sed -e 's#.*namespace/\(.*\)/sparql#\1#')
+
+# create the namespace XML properties
+export ns_tmp="/tmp/ld4p_test_$$"
+export ns_xml="${ns_tmp}_namespace_properties.xml"
+export ns_response="${ns_tmp}_namespace_response.txt"
+
+cleanup_temporary_files () {
+  rm /tmp/ld4p_test_*
+}
+
+cat > $ns_xml <<_EOF_
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<entry key="com.bigdata.rdf.sail.namespace">${bg_namespace}</entry>
+<entry key="com.bigdata.rdf.store.AbstractTripleStore.quads">false</entry>
+<entry key="com.bigdata.rdf.store.AbstractTripleStore.justify">false</entry>
+<entry key="com.bigdata.rdf.store.AbstractTripleStore.statementIdentifiers">false</entry>
+<entry key="com.bigdata.rdf.store.AbstractTripleStore.geoSpatial">false</entry>
+<entry key="com.bigdata.rdf.store.AbstractTripleStore.axiomsClass">com.bigdata.rdf.axioms.NoAxioms</entry>
+<entry key="com.bigdata.rdf.sail.truthMaintenance">false</entry>
+<entry key="com.bigdata.rdf.sail.isolatableIndices">false</entry>
+<entry key="com.bigdata.rdf.sail.textIndex">false</entry>
+</properties>
+_EOF_
+
+create_namespace () {
+  curl -s -X POST -H 'Content-type: application/xml' --data @${ns_xml} ${bg_url}/namespace | tee $ns_response
+  echo
+  if grep -q "CREATED: $bg_namespace" $ns_response; then
+    return 0
+  else
+    echo "FAILED to create test namespace"
+    return 1
+  fi
+}
+
+delete_namespace () {
+  curl -s -X DELETE ${bg_url}/namespace/${bg_namespace} | tee $ns_response
+  echo
+  if grep -q "DELETED: $bg_namespace" $ns_response; then
+    return 0
+  else
+    echo "FAILED to delete test namespace"
+    return 1
+  fi
+}
+
+reset_namespace () {
+  delete_namespace && create_namespace
+}
+
+# create or reset namespace
+create_namespace || reset_namespace
+cleanup_temporary_files
+
+
+# ---
 # Test data
 rdf_file="data/test/rdfxml/one_record.rdf"
 rdf_uri="http://ld4p-test.stanford.edu/1629059#Work"
@@ -60,4 +123,9 @@ else
   exit 1
 fi
 
+# ---
+# Cleanup namespace
+
+delete_namespace
+cleanup_temporary_files
 


### PR DESCRIPTION
Fix #16 

When the namespace does not exist already, this PR allows the script to create it and clean up, e.g.
```
$ ./blazegraph_load_test.sh http://localhost:9999/blazegraph/namespace/test/sparql
CREATED: test
Blazegraph loading MARC-RDF file data/test/one_record.rdf into graph 'http://localhost:9999/blazegraph/namespace/test/sparql'
<?xml version="1.0"?><data modified="152" milliseconds="157"/>
SUCCESS: load data completed
SUCCESS: confirmed the http://ld4p-test.stanford.edu/1629059#Work is a bf:Work in the triple store
SUCCESS: cleanup of the loaded data
DELETED: test
```

When the namespace already exists, this PR enables the script to reset the namespace and cleanup, e.g.:
```
$ ./blazegraph_load_test.sh http://localhost:9999/blazegraph/namespace/test/sparql
EXISTS: test
DELETED: test
CREATED: test
Blazegraph loading MARC-RDF file data/test/one_record.rdf into graph 'http://localhost:9999/blazegraph/namespace/test/sparql'
<?xml version="1.0"?><data modified="152" milliseconds="179"/>
SUCCESS: load data completed
SUCCESS: confirmed the http://ld4p-test.stanford.edu/1629059#Work is a bf:Work in the triple store
SUCCESS: cleanup of the loaded data
DELETED: test
```